### PR TITLE
Generate gradient with luminance

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ def index():
 def gradient(value, max, end="red"):
     """With a value from 0 to max, generate the correct gradient"""
     value = int(value)
-    c1 = Color("white")
+    c1 = Color(hsl=(0, 1, 1))
     c2 = Color(end)
     gradient = list(c1.range_to(c2, max + 1))
     value = value if value < max else value

--- a/app.py
+++ b/app.py
@@ -51,17 +51,23 @@ def gradient_precip(precip_mm):
 @app.template_filter("gradient_temp")
 def gradient_temp(temp, ideal):
     """Handle gradient for temp around ideal temp"""
-    _max = 30
+    _max = 35
     temp = temp if temp > 0 else 0
     temp = temp if temp < _max else temp
-    c1 = Color("blue")
-    c2 = Color("white")
-    gradient_cold = list(c1.range_to(c2, ideal + 1))
-    c1 = Color("white")
-    c2 = Color("red")
-    gradient_hot = list(c1.range_to(c2, _max + 1))
-    gradient = gradient_cold + gradient_hot
-    return gradient[int(temp)].hex
+
+    gradient = []
+
+    for temperature in range(ideal):
+        temp_luminance = 50 + (50 / ideal) * temperature
+        gradient.append("hsl(220,100%,{}%)".format(round(temp_luminance)))
+
+    for temperature in range(_max - ideal + 1):
+        temp_luminance = 100 - (50 / (_max - ideal + 1)) * temperature
+        gradient.append("hsl(0,100%,{}%)".format(round(temp_luminance)))
+
+    gradient.append("hsl(0,100%,50%)")
+
+    return gradient[round(temp)]
 
 
 @app.template_filter("day")

--- a/templates/index.html
+++ b/templates/index.html
@@ -84,7 +84,7 @@
                         🌧 Precipitation in mm for an hour.
                         Color scale from 0 (white) to 100 (red), based on rain probability * preciptation caped at {{ max_rain }}mm.</li>
                     <li>☔️ Rain probability, color scale from 0 (white) to 100 (red).</li>
-                    <li>🌡 Temperature in °C. Scale from 0°C (blue) to white (19°C) and from white to red (30°C).</li>
+                    <li>🌡 Temperature in °C. Scale from 0°C (blue) to white (19°C) and from white to red (35°C).</li>
                     <li>🥶 Feels like °C. Same scale as temperature.</li>
                 </ul>
             </p>


### PR DESCRIPTION
# The problem

Right now, color gradients are kinda ugly. The gradients are generated with Python `colour`. The blue -> white gradient has a lot of green in the medium values and a lot of pale gray in the high values, as seen on this screen capture:

![Screenshot 2021-09-22 at 13-09-25 🚴💨 velo france sh](https://user-images.githubusercontent.com/1781070/134334273-3a4fa4bd-28ee-4463-99c6-ac49e5872a4a.png)

The problem is that green is not seen as part of a blue -> white gradient, and it conveys a positive meaning not compatible with the temperatures it appears on (if we were to use green I'd prefer using it on the ideal temp than at 8°C).

Moreover, around 19 °C, all the colors appear very gray.

![Screenshot 2021-09-22 at 13-07-47 🚴💨 velo france sh](https://user-images.githubusercontent.com/1781070/134334824-c9fea5e0-cd09-4c22-a3da-2f868d57163f.png)

That is because `colour`'s color model uses all dimensions to generate its gradient ramps. White is seen as 0 hue, 0 saturation and 1 luminance, blue as .66 hue, 1 saturation, .5 luminance. So, the gradient will push the luminance from .5 to 1, but also desaturate the color, and change its hue (towards the greens).

# The solution

Instead on relying on `colour`, I prefer using a pure CSS way of using color: `hsl()`. Blue is `hsl(240, 100%, 50%)`, white can be `hsl(240, 100%, 100%)`. If I make a gradient ramp that only touches the luminance I get a much better gradient.

The same is done with the wind speed (but we're still using `colour`).

With the same data as the first screenshot:
![Screenshot 2021-09-22 at 13-09-15 🚴💨 velo france sh](https://user-images.githubusercontent.com/1781070/134335117-7594ec63-e40c-4a1a-88ef-05d55f7378e8.png)

With the same data as the second screenshot:
![Screenshot 2021-09-22 at 13-08-21 🚴💨 velo france sh](https://user-images.githubusercontent.com/1781070/134335024-69ab5a80-ece1-41c9-a509-51c03d66d1e0.png)



