### PR TITLE
Simplify the rain indicator

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,7 +43,7 @@ def gradient(value, max, end="red"):
 
 @app.template_filter("precip_percent")
 def precip_percent(precip_mm):
-    """Handle gradient for precip_mm"""
+    """Handle vertical scale for precip_mm"""
     precip_mm = precip_mm + 1 if precip_mm > 0 else precip_mm
     precip_mm = min(precip_mm, 6)
     return (precip_mm / 6) * 100

--- a/app.py
+++ b/app.py
@@ -41,11 +41,12 @@ def gradient(value, max, end="red"):
     return gradient[int(value)].hex
 
 
-@app.template_filter("gradient_precip")
-def gradient_precip(precip_mm):
+@app.template_filter("precip_percent")
+def precip_percent(precip_mm):
     """Handle gradient for precip_mm"""
-    precip = min(precip_mm, MAX_RAIN_ACCEPTABLE)
-    return gradient(precip * 100, int(MAX_RAIN_ACCEPTABLE * 100))
+    precip_mm = precip_mm + 1 if precip_mm > 0 else precip_mm
+    precip_mm = min(precip_mm, 6)
+    return (precip_mm / 6) * 100
 
 
 @app.template_filter("gradient_temp")

--- a/templates/index.html
+++ b/templates/index.html
@@ -47,6 +47,34 @@
         section {
             margin-top: 2em;
         }
+        td .value {
+            display: inline-flex;
+            min-height: 2.6rem;
+            min-width: 2.6rem;
+            border-radius: 1.3rem;
+            align-items: center;
+            justify-content: center;
+            padding: 0 .2rem;
+            background-color: hsla(0, 0%, 100%, 0);
+            transition: background-color .2s ease;
+        }
+        table:focus td .value,
+        table:hover td .value {
+            background-color: hsla(0, 0%, 100%, 1);
+        }
+        td.cell_precipitation {
+            position: relative;
+        }
+        td.cell_precipitation::before {
+            content: "";
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            height: var(--bg-height, 0%);
+            background-color: var(--bg-color);
+            z-index: -1;
+        }
     </style>
 </head>
 <body>
@@ -123,18 +151,18 @@
         {% for forecast in forecasts %}
         <section>
             <h2><img src="{{ forecast.day.condition.icon }}" alt="{{ forecast.day.condition.text }}"> {{ forecast.date|day }}</h2>
-            <table>
+            <table tabindex="-1">
                 <thead>
                     <tr>
                         <th></th>
                         {% for hour in forecast.hour|selectattr("is_day") %}
-                        <th>{{ hour.time.split(' ')[-1].split(':')[0] }}</th>
+                        <th>{{ hour.time.split(' ')[-1].split(':')[0] }}</th>
                         {% endfor %}
                     </tr>
                 </thead>
                 <tbody>
                     <tr>
-                        <th></th>
+                        <th title="Forecast icon"></th>
                         {% for hour in forecast.hour|selectattr("is_day") %}
                         <td><img style="max-width: 25px;" src="{{ hour.condition.icon }}" alt="{{ hour.condition.text }}"></td>
                         {% endfor %}
@@ -142,45 +170,45 @@
                     <tr>
                         <th title="Very complicated opportunity indicator">🎲</th>
                         {% for hour in forecast.hour|selectattr("is_day") %}
-                        <td style="background-color: {{ hour|proba }};"></td>
+                        <td style="background-color: {{ hour|proba }};">
+                            <span class="value"></span>
+                        </td>
                         {% endfor %}
                     </tr>
                     <tr>
                         <th title="Wind speed (kph)">💨</th>
                         {% for hour in forecast.hour|selectattr("is_day") %}
-                        <td style="background-color: {{ hour.wind_kph|gradient(max_wind) }};">{{ hour.wind_kph }}</td>
+                        <td style="background-color: {{ hour.wind_kph|gradient(max_wind) }};">
+                            <span class="value">{{ hour.wind_kph }}</span>
+                        </td>
                         {% endfor %}
                     </tr>
                     <tr>
                         <th title="Wind direction">🧭</th>
                         {% for hour in forecast.hour|selectattr("is_day") %}
-                        <td title="{{ hour.wind_dir }}"><span class="degree" style="transform: rotate({{ hour.wind_degree }}deg);">↓</span></td>
-                        {% endfor %}
-                    </tr>
-                    <tr>
-                        <th title="Precipitation (mm)">🌧</th>
-                        {% for hour in forecast.hour|selectattr("is_day") %}
-                        <td style="background-color: {{ hour.precip_mm|gradient_precip }};">
-                            {{ hour.precip_mm }}
+                        <td title="{{ hour.wind_dir }}">
+                            <span class="value">
+                                <span class="degree" style="transform: rotate({{ hour.wind_degree }}deg);">↓</span>
+                            </span>
                         </td>
                         {% endfor %}
                     </tr>
                     <tr>
                         <th title="Chance of rain">☔️</th>
                         {% for hour in forecast.hour|selectattr("is_day") %}
-                        <td style="background-color: {{ hour.chance_of_rain|gradient(100) }};">{{ hour.chance_of_rain }}%</td>
+                        <td class="cell_precipitation" style="--bg-color: hsl(210, 80%, {{ 100 - hour.chance_of_rain / 2 }}%); --bg-height: {{ hour.precip_mm|precip_percent }}%;"><span class="value">{{ hour.chance_of_rain }}%</span></td>
                         {% endfor %}
                     </tr>
                     <tr>
                         <th title="Temperature">🌡</th>
                         {% for hour in forecast.hour|selectattr("is_day") %}
-                        <td style="background-color: {{ hour.temp_c|gradient_temp(19) }};">{{ hour.temp_c }}°</td>
+                        <td style="background-color: {{ hour.temp_c|gradient_temp(19) }};"><span class="value">{{ hour.temp_c }}°</span></td>
                         {% endfor %}
                     </tr>
                     <tr>
                         <th title="Feels like">🥶</th>
                         {% for hour in forecast.hour|selectattr("is_day") %}
-                        <td style="background-color: {{ hour.feelslike_c|gradient_temp(19) }};">{{ hour.feelslike_c }}°</td>
+                        <td style="background-color: {{ hour.feelslike_c|gradient_temp(19) }};"><span class="value">{{ hour.feelslike_c }}°</span></td>
                         {% endfor %}
                     </tr>
                 </tbody>

--- a/templates/index.html
+++ b/templates/index.html
@@ -196,7 +196,9 @@
                     <tr>
                         <th title="Chance of rain">☔️</th>
                         {% for hour in forecast.hour|selectattr("is_day") %}
-                        <td class="cell_precipitation" style="--bg-color: hsl(210, 80%, {{ 100 - hour.chance_of_rain / 2 }}%); --bg-height: {{ hour.precip_mm|precip_percent }}%;"><span class="value">{{ hour.chance_of_rain }}%</span></td>
+                        <td class="cell_precipitation" style="--bg-color: hsl(210, 80%, {{ 100 - hour.chance_of_rain / 2 }}%); --bg-height: {{ hour.precip_mm|precip_percent }}%;" title="Chance of rain is {{ hour.chance_of_rain }}%, and precipitation is {{ hour.precip_mm }} millimeters.">
+                            <span class="value">{{ hour.chance_of_rain }}%</span>
+                        </td>
                         {% endfor %}
                     </tr>
                     <tr>


### PR DESCRIPTION
# The problem

Let's declutter the table! There's a lot of interesting data displayed, but some of them could be combined. The exact quantity of rain that will fall is not necessary—what I want to know is: is it a big chance of very little rain, or a little chance of a lot of rain?

# The solution

I propose that we keep only one row of data, but using the background to illustrate the quantity of rain on a vertical scale and the chance of rain as a color. To better illustrate understand that it's a risk of rain, the color has been changed from red to blue. The vertical scale doesn't stop at `MAX_RAIN_ACCEPTABLE`, but at 5mm to have a better understanding of the quantity of rain.

![image](https://user-images.githubusercontent.com/1781070/134363413-d48fda50-b6fc-437c-b47d-4241a841c3cb.png)

This PR also adds the option of more contrast for cell values on table hover/focus.